### PR TITLE
Fixed the over-flowing of text

### DIFF
--- a/ui/display/selection/preview/PreviewArticle.tsx
+++ b/ui/display/selection/preview/PreviewArticle.tsx
@@ -29,10 +29,10 @@ function PreviewArticle(props: PreviewProps) {
         />
       ) : (
         <div className="flex h-full w-full flex-col justify-center p-6">
-          <p className="whitespace-nowrap text-4xl font-black text-slate-400 dark:text-slate-500">
+          <p className="whitespace-nowrap text-2xl font-black text-slate-400 dark:text-slate-500">
             {title}
           </p>
-          <p className="whitespace-nowrap text-2xl font-bold text-slate-400 dark:text-slate-500">
+          <p className="whitespace-nowrap text-1xl font-bold text-slate-400 dark:text-slate-500">
             {description}
           </p>
         </div>


### PR DESCRIPTION
@akshatcoder-hash  ..... I have fixed the over-flowing of text. The text under the docs page which were in the box those text size were overflowing out of box

issue no - #3 

Before - 
![Screenshot from 2023-05-02 11-19-47](https://user-images.githubusercontent.com/108119109/235589224-8eea7687-20a1-4b7b-86a4-98ce7ea10f0c.png)

After fixing it -

![Screenshot from 2023-05-02 11-09-11](https://user-images.githubusercontent.com/108119109/235589270-d15241a9-054a-4ac9-a3a6-d83e5c4b06d0.png)



