### PR TITLE
Fixed the Search-bar under docs section

### DIFF
--- a/ui/layout/sidebar/Sidebar.tsx
+++ b/ui/layout/sidebar/Sidebar.tsx
@@ -40,7 +40,7 @@ function Sidebar() {
         style={{ left: "max(0px,calc(50% - 45rem))" }}
         className={`fixed inset-0 top-16 right-auto z-20 flex w-full flex-col overflow-y-auto bg-white/90 px-8 pb-10 text-sm backdrop-blur-md dark:border-slate-800 dark:bg-slate-900/90 dark:text-white md:w-[19.5rem]`}
       >
-        <nav id="nav" className="relative flex-1 space-y-4 py-6 lg:leading-6">
+       <nav id="nav" className="relative flex-1 space-y-4 py-6 lg:leading-6 w-[17rem]">
           <SearchButton />
           <ul>
             {!isLoading ? (


### PR DESCRIPTION
@akshatcoder-hash I have fixed the search-bar under docs. Before the command 'CTRL + K' was running out of search bar

The command was running out of box -

![Screenshot from 2023-05-04 23-49-56](https://user-images.githubusercontent.com/108119109/236294258-73bdbff5-a25e-4f93-bd71-42274e995819.png)

Now its fixed - 
![Screenshot from 2023-05-04 23-42-17](https://user-images.githubusercontent.com/108119109/236294387-9f8192b5-98f9-4d6e-b53f-1191ae752483.png)

